### PR TITLE
Check default qt install location instead of where Tannin had Qt installed

### DIFF
--- a/unibuild/modules/git.py
+++ b/unibuild/modules/git.py
@@ -62,8 +62,12 @@ class SuperRepository(Task):
         return self.__context_data.__contains__(keys)
 
     def process(self, progress):
+        print self.path
         if not os.path.isdir(self.path):
             os.makedirs(self.path)
+        is_initialised_process = Popen([config['paths']['git'], "rev-parse", "--is-inside-work-tree"], cwd=self.path, env=config['__environment'], stdout=subprocess.PIPE)
+        (is_initialised_stdout, is_initialised_stderr) = is_initialised_process.communicate()
+        if is_initialised_stdout.strip() != "true":
             proc = Popen([config['paths']['git'], "init"],
                          cwd=self.path,
                          env=config['__environment'])
@@ -71,7 +75,6 @@ class SuperRepository(Task):
             if proc.returncode != 0:
                 logging.error("failed to init superproject %s (returncode %s)", self._name, proc.returncode)
                 return False
-
         return True
 
 

--- a/unibuild/modules/git.py
+++ b/unibuild/modules/git.py
@@ -62,7 +62,6 @@ class SuperRepository(Task):
         return self.__context_data.__contains__(keys)
 
     def process(self, progress):
-        print self.path
         if not os.path.isdir(self.path):
             os.makedirs(self.path)
         is_initialised_process = Popen([config['paths']['git'], "rev-parse", "--is-inside-work-tree"], cwd=self.path, env=config['__environment'], stdout=subprocess.PIPE)

--- a/unimake.py
+++ b/unimake.py
@@ -220,7 +220,7 @@ def get_qt_install(qt_version, qt_minor_version, vc_version):
         for baselocation in program_files_folders:
             p = os.path.join(baselocation, "Qt", "Qt{}".format(qt_version + "." + qt_minor_version
                                                                if qt_minor_version != '' else qt_version),
-				             "{}".format(qt_version + "." + qt_minor_version
+                             "{}".format(qt_version + "." + qt_minor_version
                                          if qt_minor_version != '' else qt_version),
                              "msvc{0}_64".format(vc_year(vc_version)))
             f = os.path.join(p, "bin", "qmake.exe")

--- a/unimake.py
+++ b/unimake.py
@@ -218,8 +218,10 @@ def get_qt_install(qt_version, qt_minor_version, vc_version):
 
     try:
         for baselocation in program_files_folders:
-            p = os.path.join(baselocation, "Qt", "{}".format(qt_version + "." + qt_minor_version
-                                                             if qt_minor_version != '' else qt_version),
+            p = os.path.join(baselocation, "Qt", "Qt{}".format(qt_version + "." + qt_minor_version
+                                                               if qt_minor_version != '' else qt_version),
+				             "{}".format(qt_version + "." + qt_minor_version
+                                         if qt_minor_version != '' else qt_version),
                              "msvc{0}_64".format(vc_year(vc_version)))
             f = os.path.join(p, "bin", "qmake.exe")
             if os.path.isfile(f):


### PR DESCRIPTION
This should mean that using the Qt custom install location setting becomes unnecessary unless you're using a custom install location.

~~Right now I'm still testing this, but I'll make sure to update this once~~ I've got a confirmed working MO out of it.