### PR TITLE
Restore the check for Qt in the default location for the online installer

### DIFF
--- a/unimake.py
+++ b/unimake.py
@@ -218,6 +218,7 @@ def get_qt_install(qt_version, qt_minor_version, vc_version):
 
     try:
         for baselocation in program_files_folders:
+            # Offline installer default location
             p = os.path.join(baselocation, "Qt", "Qt{}".format(qt_version + "." + qt_minor_version
                                                                if qt_minor_version != '' else qt_version),
                              "{}".format(qt_version + "." + qt_minor_version
@@ -226,10 +227,17 @@ def get_qt_install(qt_version, qt_minor_version, vc_version):
             f = os.path.join(p, "bin", "qmake.exe")
             if os.path.isfile(f):
                 return os.path.realpath(p)
+            # Online installer default location
+            p = os.path.join(baselocation, "Qt", "{}".format(qt_version + "." + qt_minor_version
+                                                             if qt_minor_version != '' else qt_version),
+                             "msvc{0}_64".format(vc_year(vc_version)))
+            f = os.path.join(p, "bin", "qmake.exe")
+            if os.path.isfile(f):
+                return os.path.realpath(p)
     except:
         res = None
 
-    # We should try the custom VC install path as well
+    # We should try the custom Qt install path as well
     if res is None:
         try:
             p = os.path.join(config['qt_CustomInstallPath'], "{}".format(qt_version + "." + qt_minor_version


### PR DESCRIPTION
Apparently, when I 'fixed' the umbrella-doesn't-detect-the-default-Qt-install-location issue the other day, I didn't actually replace a broken piece of code with a non-broken one, but instead replaced one working one with another working one. Umbrella was looking in the default install location if you use the online installer and all the people reporting issues were using the offline installer. After seeing someone who'd used the online installer have issues which I thought I'd fixed, I realised the code that was already there was actually useful, just not to most people on the MO Discord.

This PR puts the old check back in so now we check both of the 'default' install locations. It should require minimal testing as no code is here that wasn't here already - just now two bits that were here at different times are here at the same time.